### PR TITLE
Add protocol version endpoint

### DIFF
--- a/lib/controller-layer.js
+++ b/lib/controller-layer.js
@@ -7,6 +7,10 @@ module.exports = ({modelLayer, pubSubGateway, identityProvider, fetchICEServers}
   const app = express()
   app.use(bodyParser.json({limit: '1mb'}))
 
+  app.get('/protocol-version', function (req, res) {
+    res.send({version: 1})
+  })
+
   app.get('/ice-servers', async function (req, res) {
     if (fetchICEServers) {
       res.send(await fetchICEServers())


### PR DESCRIPTION
We fetch this endpoint when initializing the client and tell the user to upgrade if they're behind. Ideally, all our protocol changes will be backwards compatible, but this gives us an escape hatch in case we need to make breaking changes.