### PR TITLE
Use throng to run the server in a clustered configuration

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-async function startServer () {
+async function startServer (id) {
   process.on('unhandledRejection', (reason) => {
     console.error(reason.stack)
   })
@@ -15,6 +15,7 @@ async function startServer () {
     port: process.env.PORT || 3000
   })
   await server.start()
+  console.log(`Worker ${id} (pid: ${process.pid}): listening on port ${server.port}`)
   return server
 }
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "request-promise-native": "^1.0.4",
     "server-destroy": "^1.0.1",
     "temp": "^0.8.3",
+    "throng": "^4.0.0",
     "uuid": "^3.0.1"
   },
   "devDependencies": {

--- a/script/server
+++ b/script/server
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
 
 const {startServer} = require('../index')
-startServer()
+const throng = require('throng')
+throng({
+  workers: process.env.WEB_CONCURRENCY || 1,
+  lifetime: Infinity
+}, startServer)


### PR DESCRIPTION
Refs: https://devcenter.heroku.com/articles/node-concurrency

When started, the server now outputs the following:

```
Starting process with command `node script/server`
Worker 2 (pid: 16): listening on port 59375
Worker 1 (pid: 13): listening on port 59375
```

We have also switched to a single Standard-2X dyno to enable this new cluster facility.

/cc: @nathansobo @jasonrudolph 