### PR TITLE
Specify an npm to a version that respects package.lock files

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "@atom/real-time-server",
   "version": "0.12.3",
   "engines": {
-    "node": "^7.10.0"
+    "node": "^7.10.0",
+    "npm": "^5.4.2"
   },
   "description": "",
   "main": "index.js",


### PR DESCRIPTION
Hopefully this ensures we maintain consistency across nodes and deploys on Heroku so we don't need to lock down our dependencies as in #9.