### PR TITLE
Allow public access to `/_ping` endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ async function startServer (id) {
     pusherSecret: process.env.PUSHER_SECRET,
     twilioAccount: process.env.TWILIO_ACCOUNT,
     twilioAuthToken: process.env.TWILIO_AUTH_TOKEN,
-    healthCheckSecret: process.env.HEALTH_CHECK_SECRET,
+    boomtownSecret: process.env.BOOMTOWN_SECRET,
     port: process.env.PORT || 3000
   })
   await server.start()

--- a/lib/controller-layer.js
+++ b/lib/controller-layer.js
@@ -6,7 +6,7 @@ const ModelLayer = require('./model-layer')
 
 const PERCENTAGE_OF_TWILIO_TTL_TO_USE_FOR_CACHE_HEADER = 0.95
 
-module.exports = ({modelLayer, pubSubGateway, identityProvider, fetchICEServers, healthCheckSecret}) => {
+module.exports = ({modelLayer, pubSubGateway, identityProvider, fetchICEServers, boomtownSecret}) => {
   const app = express()
   app.use(bodyParser.json({limit: '1mb'}))
   app.use(bugsnag.requestHandler)
@@ -70,7 +70,7 @@ module.exports = ({modelLayer, pubSubGateway, identityProvider, fetchICEServers,
 
   // For use in testing exception reporting (i.e., bugsnag integration)
   app.get('/boomtown', function (req, res) {
-    if (req.query.secret !== healthCheckSecret) {
+    if (req.query.secret !== boomtownSecret) {
       res.status(404).send({})
       return
     }

--- a/lib/server.js
+++ b/lib/server.js
@@ -7,14 +7,14 @@ const PubSubGateway = require('./pusher-pub-sub-gateway')
 
 module.exports =
 class Server {
-  constructor ({databaseURL, pusherAppId, pusherKey, pusherSecret, twilioAccount, twilioAuthToken, healthCheckSecret, port}) {
+  constructor ({databaseURL, pusherAppId, pusherKey, pusherSecret, twilioAccount, twilioAuthToken, boomtownSecret, port}) {
     this.databaseURL = databaseURL
     this.pusherAppId = pusherAppId
     this.pusherKey = pusherKey
     this.pusherSecret = pusherSecret
     this.twilioAccount = twilioAccount
     this.twilioAuthToken = twilioAuthToken
-    this.healthCheckSecret = healthCheckSecret
+    this.boomtownSecret = boomtownSecret
     this.port = port
   }
 
@@ -33,7 +33,7 @@ class Server {
       modelLayer,
       pubSubGateway,
       identityProvider,
-      healthCheckSecret: this.healthCheckSecret,
+      boomtownSecret: this.boomtownSecret,
       fetchICEServers: async () => {
         const response = JSON.parse(await request.post(twilioICEServerURL))
         return {ttl: parseInt(response.ttl), servers: response.ice_servers}


### PR DESCRIPTION
When @as-cii and I implemented the `/_ping` endpoint in https://github.com/atom/real-time-server/pull/18, I wrongly assumed that GitHub's `/_ping` endpoints were usually protected from public access. It turns out that's not the case. We're not trying to reinvent the wheel here, so let's stick to the existing convention for GitHub's `/_ping` endpoints.

Once this change is in place, I'll be able to wire up nugget to monitor the `/_ping` endpoint in https://github.com/github/puppet/pull/16539.