### PR TITLE
Rename `username` to `login` in `IdentityProvider`

### DIFF
--- a/lib/identity-provider.js
+++ b/lib/identity-provider.js
@@ -16,7 +16,7 @@ class IdentityProvider {
       }
       const response = await this.request.get('https://api.github.com/user', {headers})
       const user = JSON.parse(response)
-      return {username: user.login}
+      return {login: user.login}
     } catch (e) {
       let errorMessage, statusCode
       if (e instanceof StatusCodeError) {

--- a/test/identity-provider.test.js
+++ b/test/identity-provider.test.js
@@ -22,10 +22,10 @@ suite('IdentityProvider', () => {
     const provider = new IdentityProvider({request})
 
     const user1 = await provider.identityForToken('user-1-token')
-    assert.equal(user1.username, 'user-1')
+    assert.equal(user1.login, 'user-1')
 
     const user2 = await provider.identityForToken('user-2-token')
-    assert.equal(user2.username, 'user-2')
+    assert.equal(user2.login, 'user-2')
   })
 
   test('throws an error when given an invalid OAuth token', async () => {


### PR DESCRIPTION
real-time-client serializes the `login` property when broadcasting peer identities in the host. Hence, portal guests were receiving an incorrect version of the identity which contained an empty `login` string.

Tests were not catching this because we mock all the interactions with the identity provider, and the fake provider uses the correct `login` property.

/cc: @nathansobo @jasonrudolph 