### PR TITLE
Bump protocol version to 4

### DIFF
--- a/lib/controller-layer.js
+++ b/lib/controller-layer.js
@@ -15,7 +15,7 @@ module.exports = ({modelLayer, pubSubGateway, identityProvider, fetchICEServers,
   app.use(bugsnag.requestHandler)
 
   app.get('/protocol-version', function (req, res) {
-    res.send({version: 3})
+    res.send({version: 4})
   })
 
   app.get('/ice-servers', async function (req, res) {


### PR DESCRIPTION
This PR increments the protocol version to ensure all clients support the `ok` attribute added to responses in  https://github.com/atom/real-time-client/pull/32.