### PR TITLE
Check status of services in parallel

### DIFF
--- a/lib/controller-layer.js
+++ b/lib/controller-layer.js
@@ -82,11 +82,18 @@ module.exports = ({modelLayer, pubSubGateway, identityProvider, fetchICEServers,
   })
 
   app.get('/_ping', async function (req, res) {
+    const statuses = await Promise.all([
+      pubSubGateway.isOperational(),
+      modelLayer.isOperational(),
+      isICEServerProviderOperational(),
+      identityProvider.isOperational()
+    ])
+
     const unhealthyServices = []
-    if (!await pubSubGateway.isOperational()) unhealthyServices.push('pubSubGateway')
-    if (!await modelLayer.isOperational()) unhealthyServices.push('db')
-    if (!await isICEServerProviderOperational()) unhealthyServices.push('iceServerProvider')
-    if (!await identityProvider.isOperational()) unhealthyServices.push('identityProvider')
+    if (!statuses[0]) unhealthyServices.push('pubSubGateway')
+    if (!statuses[1]) unhealthyServices.push('db')
+    if (!statuses[2]) unhealthyServices.push('iceServerProvider')
+    if (!statuses[3]) unhealthyServices.push('identityProvider')
 
     if (unhealthyServices.length === 0) {
       res.status(200).send({


### PR DESCRIPTION
Refs: #26 

This will speed up requests to `/_ping` and, hopefully, reduce the 95th percentile response time (i.e. the metric used on Heroku to scale down or up dynos)