### PR TITLE
Bump protocol version from 4 to 5

### DIFF
--- a/lib/controller-layer.js
+++ b/lib/controller-layer.js
@@ -15,7 +15,7 @@ module.exports = ({modelLayer, pubSubGateway, identityProvider, fetchICEServers,
   app.use(bugsnag.requestHandler)
 
   app.get('/protocol-version', function (req, res) {
-    res.send({version: 4})
+    res.send({version: 5})
   })
 
   app.get('/ice-servers', async function (req, res) {


### PR DESCRIPTION
Update protocol version to reflect the changes introduced in https://github.com/atom/teletype-client/pull/44.

🍐 'ed with @as-cii 