### PR TITLE
CORS support - allowing use directly from browser

### DIFF
--- a/lib/controller-layer.js
+++ b/lib/controller-layer.js
@@ -1,5 +1,6 @@
 const assert = require('assert')
 const bugsnag = require('bugsnag')
+const cors = require('cors')
 const express = require('express')
 const bodyParser = require('body-parser')
 const {authenticate, enforceProtocol} = require('./middleware')
@@ -9,6 +10,7 @@ const PERCENTAGE_OF_TWILIO_TTL_TO_USE_FOR_CACHE_HEADER = 0.95
 
 module.exports = ({modelLayer, pubSubGateway, identityProvider, fetchICEServers, boomtownSecret}) => {
   const app = express()
+  app.use(cors())
   app.use(bodyParser.json({limit: '1mb'}))
   app.use(enforceProtocol)
   app.use(authenticate({identityProvider, ignoredPaths: ['/protocol-version', '/boomtown', '/_ping']}))

--- a/package-lock.json
+++ b/package-lock.json
@@ -321,6 +321,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cors": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.4.tgz",
+      "integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=",
+      "requires": {
+        "object-assign": "4.1.1",
+        "vary": "1.1.1"
+      }
+    },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -1207,6 +1216,11 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
       "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "on-finished": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "body-parser": "^1.17.2",
     "bugsnag": "^1.12.2",
+    "cors": "^2.8.4",
     "dotenv": "^4.0.0",
     "express": "^4.15.3",
     "newrelic": "^2.2.1",


### PR DESCRIPTION
This enables CORS headers on all requests, so teletype-client can be
used directly from within a web-browser, without any intermediate
services.

The environment variable CORS_ENABLED=true must be specified to activate
this (default: false).

Security considerations: By enabling other domains to access the API
from the browser, it opens up the potential for a malicious site to
secretly perform tasks on behalf of the user. However, this risk is
mitigated because all requests that have side-effects or expose user
specific information also require `github-oauth-token`. So in order
for a site to access the API, it requires the end-user's token, just
like Atom.