### PR TITLE
Bump protocol version from 5 to 6

### DIFF
--- a/lib/controller-layer.js
+++ b/lib/controller-layer.js
@@ -17,7 +17,7 @@ module.exports = ({modelLayer, pubSubGateway, identityProvider, fetchICEServers,
   app.use(bugsnag.requestHandler)
 
   app.get('/protocol-version', function (req, res) {
-    res.send({version: 5})
+    res.send({version: 6})
   })
 
   app.get('/ice-servers', async function (req, res) {


### PR DESCRIPTION
Refs: https://github.com/atom/teletype-client/pull/49

/cc: @nathansobo @jasonrudolph 