### PR TITLE
Instruct clients not to cache /protocol-version response

### DIFF
--- a/lib/controller-layer.js
+++ b/lib/controller-layer.js
@@ -17,6 +17,7 @@ module.exports = ({modelLayer, pubSubGateway, identityProvider, fetchICEServers,
   app.use(bugsnag.requestHandler)
 
   app.get('/protocol-version', function (req, res) {
+    res.set('Cache-Control', 'no-store')
     res.send({version: 7})
   })
 


### PR DESCRIPTION
Motivation: https://github.com/atom/teletype/issues/318#issuecomment-363538982

With the changes in this pull request, Teletype won't cache the response that it gets from https://api.teletype.atom.io/protocol-version. Instead, Teletype will make a new request each time it needs to fetch the protocol version (i.e., each time the package is initialized).

Let's roll this out and see if it helps to address the occasional [package initialization errors](https://github.com/atom/teletype/issues/318) experienced by some users.

---

Supersedes #45 

Refs https://github.com/atom/teletype-server/pull/45#pullrequestreview-103363772