### PR TITLE
Teach authentication middleware to fail early if OAuth token is missing

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -11,6 +11,11 @@ exports.authenticate = function ({identityProvider, ignoredPaths}) {
     if (ignoredPaths.includes(req.path)) return next()
 
     const oauthToken = req.headers['github-oauth-token']
+    if (oauthToken == null) {
+      res.status(401).send({message: 'Authentication required'})
+      return
+    }
+
     try {
       res.locals.identity = await identityProvider.identityForToken(oauthToken)
     } catch (error) {

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -92,7 +92,7 @@ suite('authenticate', () => {
         headers: {}
       }
       const response = new FakeResponse()
-      await authenticateMiddleware(request, response, () => { requestAllowed = false })
+      await authenticateMiddleware(request, response, () => { requestAllowed = true })
 
       assert(!requestAllowed)
       assert.equal(response.code, 401)

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -84,6 +84,21 @@ suite('authenticate', () => {
       assert.equal(response.body.message, 'Error resolving identity for token: an error')
     }
 
+    // Make a request with a missing token.
+    {
+      let requestAllowed
+      const request = {
+        path: '/some-path',
+        headers: {}
+      }
+      const response = new FakeResponse()
+      await authenticateMiddleware(request, response, () => { requestAllowed = false })
+
+      assert(!requestAllowed)
+      assert.equal(response.code, 401)
+      assert.equal(response.body.message, 'Authentication required')
+    }
+
     // Make a request to an ignored path, and don't pass a token.
     {
       let requestAllowed


### PR DESCRIPTION
For endpoints that require authentication, teletype-server looks for an OAuth token in the `GitHub-OAuth-token` request header. It then makes a [request to the GitHub API to fetch the identity associated with the OAuth token](https://developer.github.com/v3/users/#get-the-authenticated-user). Prior to this pull request, if a request lacked the required OAuth token, teletype-server would make a request to the GitHub API with no token. We can skip that step and save some resources.

With the changes in this pull request, if a request doesn't have an OAuth token, teletype-server will respond immediately with an HTTP `401` error indicating that the request lacks authentication. We won't waste time contacting the GitHub API. 😅 

### Examples

##### Request with missing token

```
$ curl -i http://localhost:3000/identity

HTTP/1.1 401 Unauthorized
...

{"message":"Authentication required"}
```

##### Request with invalid token

```
$ curl -i -H 'GitHub-OAuth-token: some-invalid-token' http://localhost:3000/identity
HTTP/1.1 401 Unauthorized
...

{"message":"Error resolving identity for token: https://api.github.com responded with 401: Bad credentials"}
```

##### Request with valid token

```
$ curl -i -H 'GitHub-OAuth-token: <REDACTED>' http://localhost:3000/identity
HTTP/1.1 200 OK
...

{"id":"2988","login":"jasonrudolph"}
```
