### PR TITLE
Add flag to disable bugsnag on the test server.

### DIFF
--- a/lib/controller-layer.js
+++ b/lib/controller-layer.js
@@ -8,13 +8,22 @@ const ModelLayer = require('./model-layer')
 
 const PERCENTAGE_OF_TWILIO_TTL_TO_USE_FOR_CACHE_HEADER = 0.95
 
-module.exports = ({modelLayer, pubSubGateway, identityProvider, fetchICEServers, boomtownSecret}) => {
+module.exports = ({
+  modelLayer,
+  pubSubGateway,
+  identityProvider,
+  fetchICEServers,
+  boomtownSecret,
+  enableExceptionReporter,
+}) => {
   const app = express()
   app.use(cors())
   app.use(bodyParser.json({limit: '1mb'}))
   app.use(enforceProtocol)
   app.use(authenticate({identityProvider, ignoredPaths: ['/', '/protocol-version', '/boomtown', '/_ping']}))
-  app.use(bugsnag.requestHandler)
+  if (enableExceptionReporter) {
+    app.use(bugsnag.requestHandler)
+  }
 
   app.get('/protocol-version', function (req, res) {
     res.set('Cache-Control', 'no-store')
@@ -121,6 +130,8 @@ module.exports = ({modelLayer, pubSubGateway, identityProvider, fetchICEServers,
     }
   }
 
-  app.use(bugsnag.errorHandler)
+  if (enableExceptionReporter) {
+    app.use(bugsnag.errorHandler)
+  }
   return app
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -50,7 +50,8 @@ class Server {
       fetchICEServers: async () => {
         const response = JSON.parse(await request.post(twilioICEServerURL))
         return {ttl: parseInt(response.ttl), servers: response.ice_servers}
-      }
+      },
+      enableExceptionReporter: true
     })
 
     return new Promise((resolve) => {


### PR DESCRIPTION
Refs: https://github.com/atom/teletype/issues/438

When running tests from the teletype package we instantiate a test server to assert the end to end integration between client and server.

This is problematic on Electron v3 because of a crash that happens due to the bugsnag module. Since this feature is not necessary in tests we decided to allow disabling it to work around the problem.

## Altenative solutions

We could have tried to upgrade to a newer version of bugnag, but since the module [is deprecated](https://www.npmjs.com/package/bugsnag), some potentially major work would be needed to be done to migrate to `@bugsnag/js`, which we consider not worth it since this module is not needed on tests.

🍐'd with @as-cii 