### PR TITLE
Removes `client_id` and `client_secret` query params from auth headers

### DIFF
--- a/lib/identity-provider.js
+++ b/lib/identity-provider.js
@@ -2,11 +2,9 @@ const {StatusCodeError} = require('request-promise-core/lib/errors')
 
 module.exports =
 class IdentityProvider {
-  constructor ({request, apiUrl, clientId, clientSecret, oauthToken}) {
+  constructor ({request, apiUrl, oauthToken}) {
     this.request = request
     this.apiUrl = apiUrl
-    this.clientId = clientId
-    this.clientSecret = clientSecret
     this.oauthToken = oauthToken
   }
 
@@ -40,16 +38,11 @@ class IdentityProvider {
   async isOperational () {
     try {
       var options = {
-        headers: {'User-Agent': 'api.teletype.atom.io'}
+        headers: {'User-Agent': 'api.teletype.atom.io'},
+        Authorization: `bearer ${this.oauthToken}`
       }
-
-      if (this.clientId && this.clientSecret) {
-        options.qs = {client_id: this.clientId, client_secret: this.clientSecret}
-      } else if (this.oauthToken) {
-        options.headers['Authorization'] = `bearer ${this.oauthToken}`
-      }
-
       await this.request.get(`${this.apiUrl}`, options)
+
       return true
     } catch (e) {
       return false


### PR DESCRIPTION
https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/#authenticating-using-query-parameters
![image](https://user-images.githubusercontent.com/15386677/79782216-a355c000-8336-11ea-9eb9-004a6875dee1.png)
**This PR updates authentication against github api without passing client_id and client_secret as query params**